### PR TITLE
Properly support rotating of the subview.

### DIFF
--- a/ZLSwipeableView/ZLSwipeableView.m
+++ b/ZLSwipeableView/ZLSwipeableView.m
@@ -86,6 +86,9 @@ const NSUInteger kNumPrefetchedViews = 3;
 
     self.anchorContainerView.frame = CGRectMake(0, 0, 1, 1);
     self.containerView.frame = self.bounds;
+    for (UIView *subView in self.containerView.subviews) {
+        subView.frame = self.containerView.bounds;
+    }
     self.reuseCoverContainerView.frame = self.bounds;
     self.swipeableViewsCenterInitial = CGPointMake(
         self.bounds.size.width / 2 + self.swipeableViewsCenterInitial.x -


### PR DESCRIPTION
When rotating the swappable view. It's subviews need an updated bounds value as well.
